### PR TITLE
Closes #59 Fix checkpoint resume logic to ensure consistent metric computation

### DIFF
--- a/__frag4/MergeSort.java
+++ b/__frag4/MergeSort.java
@@ -1,0 +1,75 @@
+package com.thealgorithms.sorts;
+
+import static com.thealgorithms.sorts.SortUtils.less;
+
+/**
+ * Generic merge sort algorithm.
+ *
+ * @see SortAlgorithm
+ */
+@SuppressWarnings("rawtypes")
+class MergeSort implements SortAlgorithm {
+
+    private Comparable[] aux;
+
+    /**
+     * Generic merge sort algorithm.
+     *
+     * Time Complexity:
+     * - Best case: O(n log n)
+     * - Average case: O(n log n)
+     * - Worst case: O(n log n)
+     *
+     * Space Complexity: O(n) – requires auxiliary array for merging.
+     *
+     * @see SortAlgorithm
+     */
+    @Override
+    public <T extends Comparable<T>> T[] sort(T[] unsorted) {
+        aux = new Comparable[unsorted.length];
+        doSort(unsorted, 0, unsorted.length - 1);
+        return unsorted;
+    }
+
+    /**
+     * @param arr the array to be sorted.
+     * @param left the first index of the array.
+     * @param right the last index of the array.
+     */
+    private <T extends Comparable<T>> void doSort(T[] arr, int left, int right) {
+        if (left < right) {
+            int mid = (left + right) >>> 1;
+            doSort(arr, left, mid);
+            doSort(arr, mid + 1, right);
+            merge(arr, left, mid, right);
+        }
+    }
+
+    /**
+     * Merges two parts of an array.
+     *
+     * @param arr the array to be merged.
+     * @param left the first index of the array.
+     * @param mid the middle index of the array.
+     * @param right the last index of the array merges two parts of an array in
+     * increasing order.
+     */
+    @SuppressWarnings("unchecked")
+    private <T extends Comparable<T>> void merge(T[] arr, int left, int mid, int right) {
+        int i = left;
+        int j = mid + 1;
+        System.arraycopy(arr, left, aux, left, right + 1 - left);
+
+        for (int k = left; k <= right; k++) {
+            if (j > right) {
+                arr[k] = (T) aux[i++];
+            } else if (i > mid) {
+                arr[k] = (T) aux[j++];
+            } else if (less(aux[j], aux[i])) {
+                arr[k] = (T) aux[j++];
+            } else {
+                arr[k] = (T) aux[i++];
+            }
+        }
+    }
+}

--- a/__frag4/RodCuttingProblemTest.kt
+++ b/__frag4/RodCuttingProblemTest.kt
@@ -1,0 +1,22 @@
+package dynamicProgramming
+
+import org.junit.Test
+
+class RodCuttingProblemTest {
+
+    @Test
+    fun testWithRodSize3() {
+        assert(rodCutting(intArrayOf(3, 8, 10)) == 11)
+    }
+
+    @Test
+    fun testWithZeroPrice() {
+        assert(rodCutting(intArrayOf(0, 0, 0)) == 0)
+    }
+
+    @Test
+    fun testWithSameValue() {
+        assert(rodCutting(intArrayOf(2, 4, 6, 8, 10)) == 10)
+    }
+
+}

--- a/__frag4/z_function.cpp
+++ b/__frag4/z_function.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file
+ * @brief The [Z function](https://cp-algorithms.com/string/z-function.html) for
+ * finding occurences of a pattern within a piece of text with time and space
+ * complexity O(n + m)
+ * @details
+ * 1. The Z-function for a string is an array of length n where the
+ * i-th element is equal to the greatest number of characters starting
+ * from the position i that coincide with the first characters of s.
+ * 2. E.g.: string: ababb then z[2]=2 as s[2]=s[0] and s[3]=s[1] and s[4]!=s[2]
+ * @author [Ritika Gupta](https://github.com/RitikaGupta8734)
+ */
+
+#include <cstdint>
+#include <iostream>  /// for IO operations
+#ifdef _MSC_VER
+#include <string>  /// for string (use this for MS Visual C++)
+#else
+#include <cstring>  /// for string
+#endif
+#include <cassert>  /// for assert
+#include <vector>   /// for std::vector
+
+/**
+ * @brief Generate the Z-function for the inputted string.
+ * \param[in] pattern text on which to apply the Z-function
+ * \returns the Z-function output as a vector array
+ */
+std::vector<uint64_t> Z_function(const std::string &pattern) {
+    uint64_t pattern_length = pattern.size();
+    std::vector<uint64_t> z(pattern_length, 0);
+
+    for (uint64_t i = 1, l = 0, r = 0; i < pattern_length; i++) {
+        if (i <= r) {
+            z[i] = std::min(r - i + 1, z[i - l]);
+        }
+        while (i + z[i] < pattern_length &&
+               pattern[z[i]] == pattern[i + z[i]]) {
+            z[i]++;
+        }
+        if (i + z[i] - 1 > r) {
+            r = i + z[i] - 1;
+        }
+    }
+    return z;
+}
+
+/**
+ * @brief Using Z_function to find a pattern in a text
+ * \param[in] pattern string pattern to search
+ * \param[in] text text in which to search
+ * \returns a vector of starting indexes where pattern is found in the text
+ */
+std::vector<uint64_t> find_pat_in_text(const std::string &pattern,
+                                       const std::string &text) {
+    uint64_t text_length = text.size(), pattern_length = pattern.size();
+    std::vector<uint64_t> z = Z_function(pattern + '#' + text);
+    std::vector<uint64_t> matching_indexes;
+
+    for (uint64_t i = 0; i < text_length; i++) {
+        if (z[i + pattern_length + 1] == pattern_length) {
+            matching_indexes.push_back(i);
+        }
+    }
+    return matching_indexes;
+}
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void test() {
+    // usual case
+    std::string text1 = "alskfjaldsabc1abc1abcbksbcdnsdabcabc";
+    std::string pattern1 = "abc";
+
+    // matching_indexes1 gets the indexes where pattern1 exists in text1
+    std::vector<uint64_t> matching_indexes1 = find_pat_in_text(pattern1, text1);
+    assert((matching_indexes1 == std::vector<uint64_t>{10, 14, 18, 30, 33}));
+
+    // corner case
+    std::string text2 = "greengrass";
+    std::string pattern2 = "abc";
+
+    // matching_indexes2 gets the indexes where pattern2 exists in text2
+    std::vector<uint64_t> matching_indexes2 = find_pat_in_text(pattern2, text2);
+    assert((matching_indexes2 == std::vector<uint64_t>{}));
+
+    // corner case - empty text
+    std::string text3 = "";
+    std::string pattern3 = "abc";
+
+    // matching_indexes3 gets the indexes where pattern3 exists in text3
+    std::vector<uint64_t> matching_indexes3 = find_pat_in_text(pattern3, text3);
+    assert((matching_indexes3 == std::vector<uint64_t>{}));
+
+    // corner case - empty pattern
+    std::string text4 = "redsand";
+    std::string pattern4 = "";
+
+    // matching_indexes4 gets the indexes where pattern4 exists in text4
+    std::vector<uint64_t> matching_indexes4 = find_pat_in_text(pattern4, text4);
+    assert((matching_indexes4 == std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6}));
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+    return 0;
+}


### PR DESCRIPTION
59 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.